### PR TITLE
Instead of validating author, always create author JSON

### DIFF
--- a/helper/packager.php
+++ b/helper/packager.php
@@ -248,15 +248,12 @@ class packager
 
 		foreach ($data['authors'] as $i => $author_data)
 		{
-			if ($data['authors'][$i]['author_name'] !== '')
-			{
-				$composer['authors'][] = array(
-					'name' => "{$data['authors'][$i]['author_name']}",
-					'email' => "{$data['authors'][$i]['author_email']}",
-					'homepage' => "{$data['authors'][$i]['author_homepage']}",
-					'role' => "{$data['authors'][$i]['author_role']}",
-				);
-			}
+			$composer['authors'][] = array(
+				'name' => "{$data['authors'][$i]['author_name']}",
+				'email' => "{$data['authors'][$i]['author_email']}",
+				'homepage' => "{$data['authors'][$i]['author_homepage']}",
+				'role' => "{$data['authors'][$i]['author_role']}",
+			);
 		}
 
 		$body = json_encode($composer, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES);

--- a/helper/validator.php
+++ b/helper/validator.php
@@ -25,16 +25,6 @@ class validator
 		$this->user = $user;
 	}
 
-	public function validate_author_name($value)
-	{
-		if (strlen($value))
-		{
-			return $value;
-		}
-
-		throw new \RuntimeException($this->user->lang('SKELETON_INVALID_AUTHOR_NAME'));
-	}
-
 	public function validate_num_authors($value)
 	{
 		if (preg_match('#^\d+$#', $value) && $value > 0 && $value <= 20)

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -108,7 +108,6 @@ $lang = array_merge($lang, array(
 	'SKELETON_TITLE_REQUIREMENT_INFO'	=> 'Requirements',
 	'SKELETON_TITLE_COMPONENT_INFO'		=> 'Components',
 
-	'SKELETON_INVALID_AUTHOR_NAME'		=> 'The author name is required',
 	'SKELETON_INVALID_EXTENSION_NAME'	=> 'The extension name you provided is invalid',
 	'SKELETON_INVALID_EXTENSION_TIME'	=> 'The extension date you provided is invalid',
 	'SKELETON_INVALID_EXTENSION_VERSION'=> 'The extension version you provided is invalid',


### PR DESCRIPTION
Leaving any author field blank creates an invalid composer.json. We should ensure the composer.json is always generated in a valid form, even if it's empty.