### PR TITLE
Put restrictions and warnings on reserved names

### DIFF
--- a/controller/main.php
+++ b/controller/main.php
@@ -168,7 +168,7 @@ class main
 
 		$this->template->assign_var('S_POST_ACTION', $this->helper->route('phpbb_skeleton_controller'));
 
-		return $this->helper->render('skeleton_body.html', $this->user->lang('PHPBB_SKELETON_EXT'));
+		return $this->helper->render('skeleton_body.html', $this->user->lang('PHPBB_CREATE_SKELETON_EXT'));
 	}
 
 	/**

--- a/helper/validator.php
+++ b/helper/validator.php
@@ -126,7 +126,7 @@ class validator
 	 */
 	public function validate_vendor_name($value)
 	{
-		if (preg_match('#^[a-zA-Z][a-zA-Z0-9]*$#', $value))
+		if ($value !== 'core' && preg_match('#^[a-zA-Z][a-zA-Z0-9]*$#', $value))
 		{
 			return $value;
 		}

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -25,7 +25,7 @@ $lang = array_merge($lang, array(
 	'CLI_DESCRIPTION_SKELETON_CREATE'	=> 'Create a basic skeleton extension',
 	'PHPBB_SKELETON_EXT'				=> 'Skeleton Extension',
 	'PHPBB_CREATE_SKELETON_EXT'			=> 'Create skeleton extension',
-	'PHPBB_SKELETON_EXT_DOCS'			=> '<a href="https://area51.phpbb.com/docs/dev/31x/extensions/skeleton_extension.html">View the documentation for more information</a>.',
+	'PHPBB_SKELETON_EXT_DOCS'			=> '<a href="https://area51.phpbb.com/docs/dev/31x/extensions/skeleton_extension.html" target="_blank">Read the Documentation</a>',
 
 	'EXTENSION_CLI_SKELETON_SUCCESS'	=> "<info>Extension created successfully.\nCopy the extension from `store/tmp-ext/` into the `ext/` folder.</info>",
 	'SKELETON_CLI_COMPOSER_QUESTIONS'	=> '<comment>Enter composer.json details (hit enter to leave an option empty)</comment>',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -30,6 +30,8 @@ $lang = array_merge($lang, array(
 	'SKELETON_CLI_COMPOSER_QUESTIONS'	=> '<comment>Enter composer.json details (hit enter to leave an option empty)</comment>',
 	'SKELETON_CLI_COMPONENT_QUESTIONS'	=> '<comment>Install optional components. Default: No; [y/n]</comment>',
 
+	'SKELETON_RESERVED_NAME_WARNING_UI'	=> 'Warning: The name entered is not allowed.',
+
 	'SKELETON_ADD_AUTHOR'						=> 'Add author',
 	'SKELETON_QUESTION_VENDOR_NAME'				=> 'Please enter the vendor name',
 	'SKELETON_QUESTION_VENDOR_NAME_UI'			=> 'Vendor name',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -23,7 +23,8 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge($lang, array(
 	'CLI_DESCRIPTION_SKELETON_CREATE'	=> 'Create a basic skeleton extension',
-	'PHPBB_SKELETON_EXT'				=> 'Create skeleton extension',
+	'PHPBB_SKELETON_EXT'				=> 'Skeleton Extension',
+	'PHPBB_CREATE_SKELETON_EXT'			=> 'Create skeleton extension',
 	'PHPBB_SKELETON_EXT_DOCS'			=> '<a href="https://area51.phpbb.com/docs/dev/31x/extensions/skeleton_extension.html">View the documentation for more information</a>.',
 
 	'EXTENSION_CLI_SKELETON_SUCCESS'	=> "<info>Extension created successfully.\nCopy the extension from `store/tmp-ext/` into the `ext/` folder.</info>",

--- a/styles/prosilver/template/editor.js
+++ b/styles/prosilver/template/editor.js
@@ -15,6 +15,7 @@
 		authorTpl = $elem.author.first().clone();
 	});
 
+	// Add Authors button
 	$elem.addAuthor.on('click', function() {
 		var count = $elem.author.length,
 			$author = authorTpl.clone();
@@ -30,6 +31,7 @@
 		$(this).before($('<hr />')).before($author);
 	});
 
+	// Mark all / unmark all components
 	$elem.marklist.on('click', function(e) {
 		e.preventDefault();
 		$elem.components.prop('checked', $(this).hasClass('markall'));

--- a/styles/prosilver/template/editor.js
+++ b/styles/prosilver/template/editor.js
@@ -37,16 +37,28 @@
 		$elem.components.prop('checked', $(this).hasClass('markall'));
 	});
 
-	// Validate vendor/extension names
+	// Validate vendor/extension names on field blur
 	$elem.form.on('blur', '#vendor_name, #extension_name', function() {
-		var $value = $(this).val(),
-			$warning = $('<div/>').css('color', 'red').text(warningMsg);
-
-		$(this).next($warning).remove();
-
-		if ($value === 'phpbb' || $value === 'core') {
-			$(this).after($warning);
-		}
+		$(this).checkNames();
 	});
+
+	// Validate vendor/extension names on document ready
+	$(document).ready(function(){
+		$('#vendor_name, #extension_name').checkNames();
+	});
+
+	/*global warningMsg */
+	$.fn.checkNames = function() {
+		return this.each(function() {
+			var $value = $(this).val(),
+				$warning = $('<div/>').css('color', 'red').text(warningMsg);
+
+			$(this).next($warning).remove();
+
+			if ($value === 'phpbb' || $value === 'core') {
+				$(this).after($warning);
+			}
+		});
+	};
 
 })(jQuery); // Avoid conflicts with other libraries

--- a/styles/prosilver/template/editor.js
+++ b/styles/prosilver/template/editor.js
@@ -4,6 +4,7 @@
 
 	var authorTpl,
 		$elem = {
+			form: $('#postform'),
 			author: $('.skeleton-author'),
 			addAuthor: $('#skeleton-new-author'),
 			components: $('.components'),
@@ -32,6 +33,18 @@
 	$elem.marklist.on('click', function(e) {
 		e.preventDefault();
 		$elem.components.prop('checked', $(this).hasClass('markall'));
+	});
+
+	// Validate vendor/extension names
+	$elem.form.on('blur', '#vendor_name, #extension_name', function() {
+		var $value = $(this).val(),
+			$warning = $('<div/>').css('color', 'red').text(warningMsg);
+
+		$(this).next($warning).remove();
+
+		if ($value === 'phpbb' || $value === 'core') {
+			$(this).after($warning);
+		}
 	});
 
 })(jQuery); // Avoid conflicts with other libraries

--- a/styles/prosilver/template/skeleton_body.html
+++ b/styles/prosilver/template/skeleton_body.html
@@ -6,7 +6,6 @@
 </script>
 
 <h2>{{ lang('PHPBB_CREATE_SKELETON_EXT') }}</h2>
-<p>{{ lang('PHPBB_SKELETON_EXT_DOCS') }}</p>
 
 <form id="postform" method="post" action="{{ S_POST_ACTION }}">
 {% if ERROR %}
@@ -19,6 +18,7 @@
 
 <div class="panel bg1">
 	<div class="inner">
+		<p class="small-icon icon-phpbb-skeleton no-bulletin rightside">{{ lang('PHPBB_SKELETON_EXT_DOCS') }}</p>
 		<h2 class="solo">{{ lang('SKELETON_TITLE_EXTENSION_INFO') }}</h2>
 		{% for extension in loops.extension %}
 			<div class="{% if loop.index is odd %}column1{% else %}column2{% endif %}">

--- a/styles/prosilver/template/skeleton_body.html
+++ b/styles/prosilver/template/skeleton_body.html
@@ -1,6 +1,10 @@
 {% include 'overall_header.html' %}
 {% INCLUDEJS '@phpbb_skeleton/editor.js' %}
 
+<script>
+	var warningMsg = '{{ lang('SKELETON_RESERVED_NAME_WARNING_UI') }}';
+</script>
+
 <h2>{{ lang('PHPBB_SKELETON_EXT') }}</h2>
 <p>{{ lang('PHPBB_SKELETON_EXT_DOCS') }}</p>
 

--- a/styles/prosilver/template/skeleton_body.html
+++ b/styles/prosilver/template/skeleton_body.html
@@ -5,7 +5,7 @@
 	var warningMsg = '{{ lang('SKELETON_RESERVED_NAME_WARNING_UI') }}';
 </script>
 
-<h2>{{ lang('PHPBB_SKELETON_EXT') }}</h2>
+<h2>{{ lang('PHPBB_CREATE_SKELETON_EXT') }}</h2>
 <p>{{ lang('PHPBB_SKELETON_EXT_DOCS') }}</p>
 
 <form id="postform" method="post" action="{{ S_POST_ACTION }}">


### PR DESCRIPTION
This does 2 small things. We do not want users trying to use "phpbb" or "core" as extension or vendor names.

So it rejects using "core" at the PHP level. (But not "phpbb" since official extensions are allowed to use it.)

It also uses J.S. in the web UI to display a warning message in red to the user if they enter "phpbb" or "core" in the extension or vendor name fields.