### PR TITLE
Prevent underscore directory

### DIFF
--- a/helper/packager.php
+++ b/helper/packager.php
@@ -178,7 +178,7 @@ class packager
 		{
 			$zip_archive->addFile(
 				$file->getRealPath(),
-				"{$data['extension']['vendor_name']}/{$data['extension']['extension_name']}/" . $file->getRelativePath() . '/' . $file->getFilename()
+				"{$data['extension']['vendor_name']}/{$data['extension']['extension_name']}/" . ($file->getRelativePath() ? $file->getRelativePath() . "/" : "") . $file->getFilename()
 			);
 		}
 


### PR DESCRIPTION
As discussed on Discord.
When currently extracting the downloaded zip, everything works fine. However, when you drag the folder out of the zip archive, an underscore `_` directory is created with the root files in them (such as `composer.json`). 
_(https://prnt.sc/lwpuyu and https://prnt.sc/lwpv38 , when dragged out transformed into an `_` directory)_

This fix allows both ways to function, both extracting and dragging.