### PR TITLE
Drop legacy support for phpBB 3.1 installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"extra": {
 		"display-name": "phpBB Skeleton Extension",
 		"soft-require": {
-			"phpbb/phpbb": ">=3.1.4"
+			"phpbb/phpbb": ">=3.2.0"
 		},
 		"version-check": {
 			"host": "www.phpbb.com",

--- a/config/console.yml
+++ b/config/console.yml
@@ -3,6 +3,7 @@ services:
         class: phpbb\skeleton\console\create
         arguments:
             - '@user'
+            - '@language'
             - '@phpbb.skeleton.helper.packager'
             - '@phpbb.skeleton.helper.validator'
         tags:

--- a/config/services.yml
+++ b/config/services.yml
@@ -8,6 +8,7 @@ services:
         arguments:
             - '@config'
             - '@controller.helper'
+            - '@language'
             - '@request'
             - '@phpbb.skeleton.helper.packager'
             - '@phpbb.skeleton.helper.validator'
@@ -25,7 +26,7 @@ services:
     phpbb.skeleton.helper.validator:
         class: phpbb\skeleton\helper\validator
         arguments:
-            - '@user'
+            - '@language'
 
     phpbb.skeleton.listener:
         class: phpbb\skeleton\event\main_listener

--- a/config/services.yml
+++ b/config/services.yml
@@ -18,7 +18,6 @@ services:
     phpbb.skeleton.helper.packager:
         class: phpbb\skeleton\helper\packager
         arguments:
-            - '@user'
             - '@service_container'
             - '@phpbb.skeleton.collection'
             - '%core.root_path%'

--- a/console/create.php
+++ b/console/create.php
@@ -57,11 +57,12 @@ class create extends command
 	 */
 	public function __construct(user $user, language $language, packager $packager, validator $validator)
 	{
-		parent::__construct($user);
-
 		$this->language = $language;
 		$this->packager = $packager;
 		$this->validator = $validator;
+
+		$this->language->add_lang('common', 'phpbb/skeleton');
+		parent::__construct($user);
 	}
 
 	/**
@@ -69,7 +70,6 @@ class create extends command
 	 */
 	protected function configure()
 	{
-		$this->language->add_lang('common', 'phpbb/skeleton');
 		$this
 			->setName('extension:create')
 			->setDescription($this->language->lang('CLI_DESCRIPTION_SKELETON_CREATE'))

--- a/console/create.php
+++ b/console/create.php
@@ -14,6 +14,7 @@
 namespace phpbb\skeleton\console;
 
 use phpbb\console\command\command;
+use phpbb\language\language;
 use phpbb\skeleton\helper\packager;
 use phpbb\skeleton\helper\validator;
 use phpbb\user;
@@ -37,6 +38,9 @@ class create extends command
 	/** @var OutputInterface */
 	protected $output;
 
+	/** @var language */
+	protected $language;
+
 	/** @var packager */
 	protected $packager;
 
@@ -46,14 +50,16 @@ class create extends command
 	/**
 	 * Constructor
 	 *
-	 * @param user $user User instance (mostly for translation)
-	 * @param packager $packager
+	 * @param user      $user
+	 * @param language  $language
+	 * @param packager  $packager
 	 * @param validator $validator
 	 */
-	public function __construct(user $user, packager $packager, validator $validator)
+	public function __construct(user $user, language $language, packager $packager, validator $validator)
 	{
 		parent::__construct($user);
 
+		$this->language = $language;
 		$this->packager = $packager;
 		$this->validator = $validator;
 	}
@@ -63,10 +69,10 @@ class create extends command
 	 */
 	protected function configure()
 	{
-		$this->user->add_lang_ext('phpbb/skeleton', 'common');
+		$this->language->add_lang('common', 'phpbb/skeleton');
 		$this
 			->setName('extension:create')
-			->setDescription($this->user->lang('CLI_DESCRIPTION_SKELETON_CREATE'))
+			->setDescription($this->language->lang('CLI_DESCRIPTION_SKELETON_CREATE'))
 		;
 	}
 
@@ -85,7 +91,7 @@ class create extends command
 	{
 		$this->packager->create_extension($this->data);
 
-		$output->writeln($this->user->lang('EXTENSION_CLI_SKELETON_SUCCESS'));
+		$output->writeln($this->language->lang('EXTENSION_CLI_SKELETON_SUCCESS'));
 	}
 
 	/**
@@ -101,10 +107,10 @@ class create extends command
 
 		$this->helper = $this->getHelper('question');
 
-		$output->writeln($this->user->lang('SKELETON_CLI_COMPOSER_QUESTIONS'));
+		$output->writeln($this->language->lang('SKELETON_CLI_COMPOSER_QUESTIONS'));
 		$this->get_composer_data();
 
-		$output->writeln($this->user->lang('SKELETON_CLI_COMPONENT_QUESTIONS'));
+		$output->writeln($this->language->lang('SKELETON_CLI_COMPONENT_QUESTIONS'));
 		$this->get_component_data();
 	}
 
@@ -119,7 +125,7 @@ class create extends command
 			$this->data['extension'][$value] = $this->get_user_input($value, $default);
 		}
 
-		$question = new Question($this->user->lang('SKELETON_QUESTION_NUM_AUTHORS') . $this->user->lang('COLON'), 1);
+		$question = new Question($this->language->lang('SKELETON_QUESTION_NUM_AUTHORS') . $this->language->lang('COLON'), 1);
 		$question->setValidator(array($this->validator, 'validate_num_authors'));
 		$num_authors = $this->helper->ask($this->input, $this->output, $question);
 
@@ -168,7 +174,7 @@ class create extends command
 	 */
 	protected function get_user_input($value, $default)
 	{
-		$dialog = $this->user->lang('SKELETON_QUESTION_' . strtoupper($value)) . $this->user->lang('COLON');
+		$dialog = $this->language->lang('SKELETON_QUESTION_' . strtoupper($value)) . $this->language->lang('COLON');
 
 		if (method_exists($this->validator, 'validate_' . $value))
 		{

--- a/controller/main.php
+++ b/controller/main.php
@@ -83,6 +83,7 @@ class main
 	 * Demo controller for route /skeleton
 	 *
 	 * @throws http_exception
+	 * @throws \Exception
 	 *
 	 * @return \Symfony\Component\HttpFoundation\Response A Symfony Response object
 	 */
@@ -231,8 +232,6 @@ class main
 	 * @param mixed    $default
 	 * @param null|int $array_key for multi user support
 	 *
-	 * @throws \Exception
-	 *
 	 * @return mixed|string
 	 */
 	protected function get_user_input($value, $default, $array_key = null)
@@ -260,8 +259,6 @@ class main
 	 * @param string   $value
 	 * @param mixed    $default
 	 * @param null|int $array_key for multi user support
-	 *
-	 * @throws \Exception
 	 *
 	 * @return mixed|string
 	 */

--- a/controller/main.php
+++ b/controller/main.php
@@ -16,6 +16,7 @@ namespace phpbb\skeleton\controller;
 use phpbb\config\config;
 use phpbb\controller\helper;
 use phpbb\exception\http_exception;
+use phpbb\language\language;
 use phpbb\request\request;
 use phpbb\skeleton\helper\packager;
 use phpbb\skeleton\helper\validator;
@@ -33,6 +34,9 @@ class main
 
 	/* @var helper */
 	protected $helper;
+
+	/** @var language */
+	protected $language;
 
 	/* @var request */
 	protected $request;
@@ -54,23 +58,25 @@ class main
 	 *
 	 * @param config    $config
 	 * @param helper    $helper
+	 * @param language  $language
 	 * @param request   $request
 	 * @param packager  $packager
 	 * @param validator $validator
 	 * @param template  $template
 	 * @param user      $user
 	 */
-	public function __construct(config $config, helper $helper, request $request, packager $packager, validator $validator, template $template, user $user)
+	public function __construct(config $config, helper $helper, language $language, request $request, packager $packager, validator $validator, template $template, user $user)
 	{
 		$this->config = $config;
 		$this->helper = $helper;
+		$this->language = $language;
 		$this->request = $request;
 		$this->packager = $packager;
 		$this->validator = $validator;
 		$this->template = $template;
 		$this->user = $user;
 
-		$this->user->add_lang_ext('phpbb/skeleton', 'common');
+		$this->language->add_lang('common', 'phpbb/skeleton');
 	}
 
 	/**
@@ -117,8 +123,8 @@ class main
 		{
 			$this->template->assign_block_vars('extension', array(
 				'NAME'			=> $value,
-				'DESC'			=> $this->user->lang('SKELETON_QUESTION_' . strtoupper($value) . '_UI'),
-				'DESC_EXPLAIN'	=> array_key_exists('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN', $this->user->lang) ? $this->user->lang('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') : '',
+				'DESC'			=> $this->language->lang('SKELETON_QUESTION_' . strtoupper($value) . '_UI'),
+				'DESC_EXPLAIN'	=> $this->language->is_set('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') ? $this->language->lang('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') : '',
 				'VALUE'			=> $this->request->variable($value, (string) $default, true),
 			));
 		}
@@ -136,8 +142,8 @@ class main
 			{
 				$this->template->assign_block_vars('author', array(
 					'NAME'			=> $value,
-					'DESC'			=> $this->user->lang('SKELETON_QUESTION_' . strtoupper($value) . '_UI'),
-					'DESC_EXPLAIN'	=> array_key_exists('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN', $this->user->lang) ? $this->user->lang('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') : '',
+					'DESC'			=> $this->language->lang('SKELETON_QUESTION_' . strtoupper($value) . '_UI'),
+					'DESC_EXPLAIN'	=> $this->language->is_set('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') ? $this->language->lang('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') : '',
 					'VALUE'			=> isset($author_values[$value][$i]) ? $author_values[$value][$i] : '',
 				));
 			}
@@ -147,8 +153,8 @@ class main
 		{
 			$this->template->assign_block_vars('requirement', array(
 				'NAME'			=> $value,
-				'DESC'			=> $this->user->lang('SKELETON_QUESTION_' . strtoupper($value) . '_UI'),
-				'DESC_EXPLAIN'	=> array_key_exists('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN', $this->user->lang) ? $this->user->lang('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') : '',
+				'DESC'			=> $this->language->lang('SKELETON_QUESTION_' . strtoupper($value) . '_UI'),
+				'DESC_EXPLAIN'	=> $this->language->is_set('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') ? $this->language->lang('SKELETON_QUESTION_' . strtoupper($value) . '_EXPLAIN') : '',
 				'VALUE'			=> $this->request->variable($value, (string) $default),
 			));
 		}
@@ -158,8 +164,8 @@ class main
 		{
 			$this->template->assign_block_vars('component', array(
 				'NAME'			=> 'component_' . $component,
-				'DESC'			=> $this->user->lang('SKELETON_QUESTION_COMPONENT_' . strtoupper($component) . '_UI'),
-				'DESC_EXPLAIN'	=> array_key_exists('SKELETON_QUESTION_COMPONENT_' . strtoupper($component) . '_EXPLAIN', $this->user->lang) ? $this->user->lang('SKELETON_QUESTION_COMPONENT_' . strtoupper($component) . '_EXPLAIN') : '',
+				'DESC'			=> $this->language->lang('SKELETON_QUESTION_COMPONENT_' . strtoupper($component) . '_UI'),
+				'DESC_EXPLAIN'	=> $this->language->is_set('SKELETON_QUESTION_COMPONENT_' . strtoupper($component) . '_EXPLAIN') ? $this->language->lang('SKELETON_QUESTION_COMPONENT_' . strtoupper($component) . '_EXPLAIN') : '',
 				'VALUE'			=> $this->request->variable('component_' . $component, $details['default']),
 			));
 
@@ -168,7 +174,7 @@ class main
 
 		$this->template->assign_var('S_POST_ACTION', $this->helper->route('phpbb_skeleton_controller'));
 
-		return $this->helper->render('skeleton_body.html', $this->user->lang('PHPBB_CREATE_SKELETON_EXT'));
+		return $this->helper->render('skeleton_body.html', $this->language->lang('PHPBB_CREATE_SKELETON_EXT'));
 	}
 
 	/**

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -23,7 +23,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class main_listener implements EventSubscriberInterface
 {
-	static public function getSubscribedEvents()
+	public static function getSubscribedEvents()
 	{
 		return array(
 			'core.user_setup'	=> 'load_language_on_setup',

--- a/ext.php
+++ b/ext.php
@@ -22,7 +22,7 @@ class ext extends \phpbb\extension\base
 	 */
 	public function is_enableable()
 	{
-		return $this->php_requirements() && ($this->phpbb_31x_compatible() || $this->phpbb_current_compatible());
+		return $this->php_requirements() && $this->phpbb_compatible();
 	}
 
 	/**
@@ -39,27 +39,14 @@ class ext extends \phpbb\extension\base
 	}
 
 	/**
-	 * Check phpBB 3.2 (and later) compatibility
+	 * Check phpBB compatibility
 	 *
-	 * Requires phpBB 3.2.0-b3 or greater
-	 *
-	 * @return bool
-	 */
-	protected function phpbb_current_compatible()
-	{
-		return phpbb_version_compare(PHPBB_VERSION, '3.2.0-b3', '>=');
-	}
-
-	/**
-	 * Check phpBB 3.1 compatibility
-	 *
-	 * Requires phpBB 3.1.4 or greater
+	 * Requires phpBB 3.2.0 or greater
 	 *
 	 * @return bool
 	 */
-	protected function phpbb_31x_compatible()
+	protected function phpbb_compatible()
 	{
-		return phpbb_version_compare(PHPBB_VERSION, '3.1.4', '>=') && phpbb_version_compare(PHPBB_VERSION, '3.2.0-dev', '<');
+		return phpbb_version_compare(PHPBB_VERSION, '3.2.0', '>=');
 	}
 }
-

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -193,18 +193,18 @@ class packager
 		$composer = array(
 			'name'        => "{$data['extension']['vendor_name']}/{$data['extension']['extension_name']}",
 			'type'        => 'phpbb-extension',
-			'description' => "{$data['extension']['extension_description']}",
-			'homepage'    => "{$data['extension']['extension_homepage']}",
-			'version'     => "{$data['extension']['extension_version']}",
-			'time'        => "{$data['extension']['extension_time']}",
+			'description' => (string) $data['extension']['extension_description'],
+			'homepage'    => (string) $data['extension']['extension_homepage'],
+			'version'     => (string) $data['extension']['extension_version'],
+			'time'        => (string) $data['extension']['extension_time'],
 			'license'     => 'GPL-2.0-only',
 			'authors'     => array(),
 			'require'     => array(
-				'php'     => "{$data['requirements']['php_version']}",
+				'php'     => (string) $data['requirements']['php_version'],
 				'composer/installers' => '~1.0',
 			),
 			'extra'       => array(
-				'display-name' => "{$data['extension']['extension_display_name']}",
+				'display-name' => (string) $data['extension']['extension_display_name'],
 				'soft-require' => array(
 					'phpbb/phpbb' => "{$data['requirements']['phpbb_version_min']},{$data['requirements']['phpbb_version_max']}",
 				),
@@ -219,10 +219,10 @@ class packager
 		foreach ($data['authors'] as $i => $author_data)
 		{
 			$composer['authors'][] = array(
-				'name'     => "{$data['authors'][$i]['author_name']}",
-				'email'    => "{$data['authors'][$i]['author_email']}",
-				'homepage' => "{$data['authors'][$i]['author_homepage']}",
-				'role'     => "{$data['authors'][$i]['author_role']}",
+				'name'     => (string) $data['authors'][$i]['author_name'],
+				'email'    => (string) $data['authors'][$i]['author_email'],
+				'homepage' => (string) $data['authors'][$i]['author_homepage'],
+				'role'     => (string) $data['authors'][$i]['author_role'],
 			);
 		}
 

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -71,9 +71,9 @@ class packager
 				'extension_homepage'     => null,
 			),
 			'requirements' => array(
-				'php_version'       => '>=5.3.3',
-				'phpbb_version_min' => '>=3.1.4',
-				'phpbb_version_max' => '<3.2.0@dev',
+				'php_version'       => '>=5.4',
+				'phpbb_version_min' => '>=3.2.0',
+				'phpbb_version_max' => '<3.3.0@dev',
 			),
 		);
 	}

--- a/helper/validator.php
+++ b/helper/validator.php
@@ -14,21 +14,21 @@
 namespace phpbb\skeleton\helper;
 
 use phpbb\exception\runtime_exception;
-use phpbb\user;
+use phpbb\language\language;
 
 class validator
 {
-	/** @var user */
-	protected $user;
+	/** @var language */
+	protected $language;
 
 	/**
 	 * Constructor
 	 *
-	 * @param \phpbb\user $user
+	 * @param language $language
 	 */
-	public function __construct(user $user)
+	public function __construct(language $language)
 	{
-		$this->user = $user;
+		$this->language = $language;
 	}
 
 	/**
@@ -46,7 +46,7 @@ class validator
 			return $value;
 		}
 
-		throw new runtime_exception($this->user->lang('SKELETON_INVALID_NUM_AUTHORS'));
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_NUM_AUTHORS'));
 	}
 
 	/**
@@ -63,7 +63,7 @@ class validator
 			return $value;
 		}
 
-		throw new runtime_exception($this->user->lang('SKELETON_INVALID_PACKAGE_NAME'));
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_PACKAGE_NAME'));
 	}
 
 	/**
@@ -80,7 +80,7 @@ class validator
 			return $value;
 		}
 
-		throw new runtime_exception($this->user->lang('SKELETON_INVALID_DISPLAY_NAME'));
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_DISPLAY_NAME'));
 	}
 
 	/**
@@ -97,7 +97,7 @@ class validator
 			return $value;
 		}
 
-		throw new runtime_exception($this->user->lang('SKELETON_INVALID_EXTENSION_TIME'));
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_EXTENSION_TIME'));
 	}
 
 	/**
@@ -114,7 +114,7 @@ class validator
 			return $value;
 		}
 
-		throw new runtime_exception($this->user->lang('SKELETON_INVALID_EXTENSION_VERSION'));
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_EXTENSION_VERSION'));
 	}
 
 	/**
@@ -131,6 +131,6 @@ class validator
 			return $value;
 		}
 
-		throw new runtime_exception($this->user->lang('SKELETON_INVALID_VENDOR_NAME'));
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_VENDOR_NAME'));
 	}
 }

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -69,13 +69,13 @@ $lang = array_merge($lang, array(
 
 	'SKELETON_QUESTION_PHP_VERSION'					=> 'Please enter the PHP requirement of the extension',
 	'SKELETON_QUESTION_PHP_VERSION_UI'				=> 'PHP requirement of the extension',
-	'SKELETON_QUESTION_PHP_VERSION_EXPLAIN'			=> 'default: &gt;=5.3.3',
+	'SKELETON_QUESTION_PHP_VERSION_EXPLAIN'			=> 'default: &gt;=5.4',
 	'SKELETON_QUESTION_PHPBB_VERSION_MIN'			=> 'Please enter the minimum phpBB requirement of the extension',
 	'SKELETON_QUESTION_PHPBB_VERSION_MIN_UI'		=> 'Minimum phpBB requirement of the extension',
-	'SKELETON_QUESTION_PHPBB_VERSION_MIN_EXPLAIN'	=> 'default: &gt;=3.1.4',
+	'SKELETON_QUESTION_PHPBB_VERSION_MIN_EXPLAIN'	=> 'default: &gt;=3.2.0',
 	'SKELETON_QUESTION_PHPBB_VERSION_MAX'			=> 'Please enter the maximum phpBB requirement of the extension',
 	'SKELETON_QUESTION_PHPBB_VERSION_MAX_UI'		=> 'Maximum phpBB requirement of the extension',
-	'SKELETON_QUESTION_PHPBB_VERSION_MAX_EXPLAIN'	=> 'default: &lt;3.2.0@dev',
+	'SKELETON_QUESTION_PHPBB_VERSION_MAX_EXPLAIN'	=> 'default: &lt;3.3.0@dev',
 
 	'SKELETON_QUESTION_COMPONENT_PHPLISTENER'		=> 'Create sample PHP event listeners?',
 	'SKELETON_QUESTION_COMPONENT_PHPLISTENER_UI'	=> 'PHP event listeners',


### PR DESCRIPTION
This updates the skeleton ext for phpBB 3.2 and newer, and can no longer be installed on 3.1. However, the skeleton can still generate extensions with support for 3.1 and 3.2 boards.