### PR TITLE
Language object

### DIFF
--- a/helper/packager.php
+++ b/helper/packager.php
@@ -119,6 +119,7 @@ class packager
 			'EXTENSION'    => $data['extension'],
 			'REQUIREMENTS' => $data['requirements'],
 			'AUTHORS'      => $data['authors'],
+			'LANGUAGE'     => $this->get_language_object($data['requirements']['phpbb_version_min']),
 		));
 
 		$component_data = $this->get_component_dialog_values();
@@ -266,5 +267,17 @@ class packager
 		);
 
 		return $template_engine;
+	}
+
+	protected function get_language_object($min_version)
+	{
+		$phpbb31 = (bool) preg_match('/^[\\D]*3\\.1.*$/', $min_version);
+
+		return array(
+			'class'		=> $phpbb31 ? '\phpbb\user' : '\phpbb\language\language',
+			'service'	=> $phpbb31 ? 'user' : 'language',
+			'function'	=> $phpbb31 ? 'add_lang_ext' : 'add_lang',
+			's_32'		=> !$phpbb31,
+		);
 	}
 }

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -277,6 +277,10 @@ class packager
 			'class'		=> $phpbb31 ? '\phpbb\user' : '\phpbb\language\language',
 			'object'	=> $phpbb31 ? 'user' : 'language',
 			'function'	=> $phpbb31 ? 'add_lang_ext' : 'add_lang',
+			'indent'	=> array(
+				'class'		=> $phpbb31 ? "\t\t\t" : '',
+				'object'	=> $phpbb31 ? "\t" : '',
+			),
 		);
 	}
 }

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -119,7 +119,7 @@ class packager
 			'EXTENSION'    => $data['extension'],
 			'REQUIREMENTS' => $data['requirements'],
 			'AUTHORS'      => $data['authors'],
-			'LANGUAGE'     => $this->get_language_object($data['requirements']['phpbb_version_min']),
+			'LANGUAGE'     => $this->get_language_version_data($data['requirements']['phpbb_version_min']),
 		));
 
 		$component_data = $this->get_component_dialog_values();
@@ -269,15 +269,14 @@ class packager
 		return $template_engine;
 	}
 
-	protected function get_language_object($min_version)
+	protected function get_language_version_data($min_version)
 	{
 		$phpbb31 = (bool) preg_match('/^[\\D]*3\\.1.*$/', $min_version);
 
 		return array(
 			'class'		=> $phpbb31 ? '\phpbb\user' : '\phpbb\language\language',
-			'service'	=> $phpbb31 ? 'user' : 'language',
+			'object'	=> $phpbb31 ? 'user' : 'language',
 			'function'	=> $phpbb31 ? 'add_lang_ext' : 'add_lang',
-			's_32'		=> !$phpbb31,
 		);
 	}
 }

--- a/skeleton/acp/main_module.php.twig
+++ b/skeleton/acp/main_module.php.twig
@@ -26,14 +26,14 @@ class main_module
 		/** @var \{{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\acp_controller $acp_controller */
 		$acp_controller = $phpbb_container->get('{{ EXTENSION.vendor_name }}.{{ EXTENSION.extension_name }}.controller.acp');
 
-		/** @var \phpbb\language\language $language */
-		$language = $phpbb_container->get('language');
+		/** @var {{ LANGUAGE.class }} ${{ LANGUAGE.service }} */
+		${{ LANGUAGE.service }} = $phpbb_container->get('{{ LANGUAGE.service }}');
 
 		// Load a template from adm/style for our ACP page
 		$this->tpl_name = 'acp_{{ EXTENSION.extension_name|lower }}_body';
 
 		// Set the page title for our ACP page
-		$this->page_title = $language->lang('ACP_{{ EXTENSION.extension_name|upper }}_TITLE');
+		$this->page_title = ${{ LANGUAGE.service }}->lang('ACP_{{ EXTENSION.extension_name|upper }}_TITLE');
 
 		// Make the $u_action url available in our ACP controller
 		$acp_controller->set_page_url($this->u_action);

--- a/skeleton/acp/main_module.php.twig
+++ b/skeleton/acp/main_module.php.twig
@@ -26,14 +26,14 @@ class main_module
 		/** @var \{{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\acp_controller $acp_controller */
 		$acp_controller = $phpbb_container->get('{{ EXTENSION.vendor_name }}.{{ EXTENSION.extension_name }}.controller.acp');
 
-		/** @var {{ LANGUAGE.class }} ${{ LANGUAGE.service }} */
-		${{ LANGUAGE.service }} = $phpbb_container->get('{{ LANGUAGE.service }}');
+		/** @var {{ LANGUAGE.class }} ${{ LANGUAGE.object }} */
+		${{ LANGUAGE.object }} = $phpbb_container->get('{{ LANGUAGE.object }}');
 
 		// Load a template from adm/style for our ACP page
 		$this->tpl_name = 'acp_{{ EXTENSION.extension_name|lower }}_body';
 
 		// Set the page title for our ACP page
-		$this->page_title = ${{ LANGUAGE.service }}->lang('ACP_{{ EXTENSION.extension_name|upper }}_TITLE');
+		$this->page_title = ${{ LANGUAGE.object }}->lang('ACP_{{ EXTENSION.extension_name|upper }}_TITLE');
 
 		// Make the $u_action url available in our ACP controller
 		$acp_controller->set_page_url($this->u_action);

--- a/skeleton/config/services.yml.twig
+++ b/skeleton/config/services.yml.twig
@@ -65,7 +65,7 @@ services:
         arguments:
             - '@controller.helper'
             - '@template'
-            - '@user'
+            - '@{{ LANGUAGE.object }}'
             - '%core.php_ext%'
 {% endif %}
         tags:

--- a/skeleton/config/services.yml.twig
+++ b/skeleton/config/services.yml.twig
@@ -19,7 +19,8 @@ services:
         class: {{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\acp_controller
         arguments:
             - '@config'
-            - '@language'
+{% if LANGUAGE.s_32 %}            - '@language'
+{% endif %}
             - '@log'
             - '@request'
             - '@template'

--- a/skeleton/config/services.yml.twig
+++ b/skeleton/config/services.yml.twig
@@ -32,7 +32,7 @@ services:
     {{ EXTENSION.vendor_name }}.{{ EXTENSION.extension_name }}.controller.mcp:
         class: {{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\mcp_controller
         arguments:
-            - '@language'
+            - '@{{ LANGUAGE.object }}'
             - '@request'
             - '@template'
 

--- a/skeleton/config/services.yml.twig
+++ b/skeleton/config/services.yml.twig
@@ -42,7 +42,9 @@ services:
         class: {{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\ucp_controller
         arguments:
             - '@dbal.conn'
+{% if LANGUAGE.object == 'language' %}
             - '@language'
+{% endif %}
             - '@request'
             - '@template'
             - '@user'

--- a/skeleton/config/services.yml.twig
+++ b/skeleton/config/services.yml.twig
@@ -19,7 +19,8 @@ services:
         class: {{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\acp_controller
         arguments:
             - '@config'
-{% if LANGUAGE.s_32 %}            - '@language'
+{% if LANGUAGE.object == 'language' %}
+            - '@language'
 {% endif %}
             - '@log'
             - '@request'

--- a/skeleton/config/services.yml.twig
+++ b/skeleton/config/services.yml.twig
@@ -11,7 +11,7 @@ services:
             - '@config'
             - '@controller.helper'
             - '@template'
-            - '@user'
+            - '@{{ LANGUAGE.object }}'
 
 {% endif %}
 {% if COMPONENT.acp %}

--- a/skeleton/controller/acp_controller.php.twig
+++ b/skeleton/controller/acp_controller.php.twig
@@ -17,7 +17,7 @@ class acp_controller
 {
 	/** @var \phpbb\config\config */
 	protected $config;
-{% if LANGUAGE.s_32 %}
+{% if LANGUAGE.object == 'language' %}
 
 	/** @var \phpbb\language\language */
 	protected $language;
@@ -42,17 +42,19 @@ class acp_controller
 	 * Constructor.
 	 *
 	 * @param \phpbb\config\config		$config		Config object
-{% if LANGUAGE.s_32 %}	 * @param \phpbb\language\language	$language	Language object
+{% if LANGUAGE.object == 'language' %}
+	 * @param \phpbb\language\language	$language	Language object
 {% endif %}
 	 * @param \phpbb\log\log			$log		Log object
 	 * @param \phpbb\request\request	$request	Request object
 	 * @param \phpbb\template\template	$template	Template object
 	 * @param \phpbb\user				$user		User object
 	 */
-	public function __construct(\phpbb\config\config $config,{% if LANGUAGE.s_32 %} \phpbb\language\language $language,{% endif %} \phpbb\log\log $log, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\user $user)
+	public function __construct(\phpbb\config\config $config,{% if LANGUAGE.object == 'language' %} \phpbb\language\language $language,{% endif %} \phpbb\log\log $log, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\user $user)
 	{
 		$this->config	= $config;
-{% if LANGUAGE.s_32 %}		$this->language	= $language;
+{% if LANGUAGE.object == 'language' %}
+		$this->language	= $language;
 {% endif %}
 		$this->log		= $log;
 		$this->request	= $request;
@@ -68,7 +70,11 @@ class acp_controller
 	public function display_options()
 	{
 		// Add our common language file
-		$this->{{ LANGUAGE.service }}->{{ LANGUAGE.function }}({% if LANGUAGE.s_32 %}'common', {% endif %}'{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}'{% if not LANGUAGE.s_32 %}, 'common'{% endif %});
+{% if LANGUAGE.object == 'language' %}
+		$this->{{ LANGUAGE.object }}->{{ LANGUAGE.function }}('common', '{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}');
+{% else %}
+		$this->{{ LANGUAGE.object }}->{{ LANGUAGE.function }}('{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}', 'common');
+{% endif %}
 
 		// Create a form key for preventing CSRF attacks
 		add_form_key('{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_acp');
@@ -82,7 +88,7 @@ class acp_controller
 			// Test if the submitted form is valid
 			if (!check_form_key('{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_acp'))
 			{
-				$errors[] = $this->{{ LANGUAGE.service }}->lang('FORM_INVALID');
+				$errors[] = $this->{{ LANGUAGE.object }}->lang('FORM_INVALID');
 			}
 
 			// If no errors, process the form data
@@ -96,7 +102,7 @@ class acp_controller
 
 				// Option settings have been updated and logged
 				// Confirm this to the user and provide link back to previous page
-				trigger_error($this->{{ LANGUAGE.service }}->lang('ACP_{{ EXTENSION.extension_name|upper }}_SETTING_SAVED') . adm_back_link($this->u_action));
+				trigger_error($this->{{ LANGUAGE.object }}->lang('ACP_{{ EXTENSION.extension_name|upper }}_SETTING_SAVED') . adm_back_link($this->u_action));
 			}
 		}
 

--- a/skeleton/controller/acp_controller.php.twig
+++ b/skeleton/controller/acp_controller.php.twig
@@ -17,9 +17,11 @@ class acp_controller
 {
 	/** @var \phpbb\config\config */
 	protected $config;
+{% if LANGUAGE.s_32 %}
 
 	/** @var \phpbb\language\language */
-	protected $lang;
+	protected $language;
+{% endif %}
 
 	/** @var \phpbb\log\log */
 	protected $log;
@@ -40,16 +42,18 @@ class acp_controller
 	 * Constructor.
 	 *
 	 * @param \phpbb\config\config		$config		Config object
-	 * @param \phpbb\language\language	$lang		Language object
+{% if LANGUAGE.s_32 %}	 * @param \phpbb\language\language	$language	Language object
+{% endif %}
 	 * @param \phpbb\log\log			$log		Log object
 	 * @param \phpbb\request\request	$request	Request object
 	 * @param \phpbb\template\template	$template	Template object
 	 * @param \phpbb\user				$user		User object
 	 */
-	public function __construct(\phpbb\config\config $config, \phpbb\language\language $lang, \phpbb\log\log $log, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\user $user)
+	public function __construct(\phpbb\config\config $config,{% if LANGUAGE.s_32 %} \phpbb\language\language $language,{% endif %} \phpbb\log\log $log, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\user $user)
 	{
 		$this->config	= $config;
-		$this->lang		= $lang;
+{% if LANGUAGE.s_32 %}		$this->language	= $language;
+{% endif %}
 		$this->log		= $log;
 		$this->request	= $request;
 		$this->template	= $template;
@@ -64,7 +68,7 @@ class acp_controller
 	public function display_options()
 	{
 		// Add our common language file
-		$this->lang->add_lang('common', '{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}');
+		$this->{{ LANGUAGE.service }}->{{ LANGUAGE.function }}({% if LANGUAGE.s_32 %}'common', {% endif %}'{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}'{% if not LANGUAGE.s_32 %}, 'common'{% endif %});
 
 		// Create a form key for preventing CSRF attacks
 		add_form_key('{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_acp');
@@ -78,7 +82,7 @@ class acp_controller
 			// Test if the submitted form is valid
 			if (!check_form_key('{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_acp'))
 			{
-				$errors[] = $this->lang->lang('FORM_INVALID');
+				$errors[] = $this->{{ LANGUAGE.service }}->lang('FORM_INVALID');
 			}
 
 			// If no errors, process the form data
@@ -92,7 +96,7 @@ class acp_controller
 
 				// Option settings have been updated and logged
 				// Confirm this to the user and provide link back to previous page
-				trigger_error($this->lang->lang('ACP_{{ EXTENSION.extension_name|upper }}_SETTING_SAVED') . adm_back_link($this->u_action));
+				trigger_error($this->{{ LANGUAGE.service }}->lang('ACP_{{ EXTENSION.extension_name|upper }}_SETTING_SAVED') . adm_back_link($this->u_action));
 			}
 		}
 

--- a/skeleton/controller/main_controller.php.twig
+++ b/skeleton/controller/main_controller.php.twig
@@ -24,8 +24,8 @@ class main_controller
 	/** @var \phpbb\template\template */
 	protected $template;
 
-	/** @var \phpbb\user */
-	protected $user;
+	/** @var {{ LANGUAGE.class }} */
+	protected ${{ LANGUAGE.object }};
 
 	/**
 	 * Constructor
@@ -33,14 +33,14 @@ class main_controller
 	 * @param \phpbb\config\config		$config		Config object
 	 * @param \phpbb\controller\helper	$helper		Controller helper object
 	 * @param \phpbb\template\template	$template	Template object
-	 * @param \phpbb\user				$user		User object
+	 * @param {{ LANGUAGE.class ~ LANGUAGE.indent.class }}	${{ LANGUAGE.object ~ LANGUAGE.indent.object}}	{{ LANGUAGE.object|capitalize }} object
 	 */
-	public function __construct(\phpbb\config\config $config, \phpbb\controller\helper $helper, \phpbb\template\template $template, \phpbb\user $user)
+	public function __construct(\phpbb\config\config $config, \phpbb\controller\helper $helper, \phpbb\template\template $template, {{ LANGUAGE.class }} ${{ LANGUAGE.object }})
 	{
 		$this->config	= $config;
 		$this->helper	= $helper;
 		$this->template	= $template;
-		$this->user		= $user;
+		$this->{{ LANGUAGE.object ~ LANGUAGE.indent.object }}	= ${{ LANGUAGE.object }};
 	}
 
 	/**
@@ -53,7 +53,7 @@ class main_controller
 	public function handle($name)
 	{
 		$l_message = !$this->config['{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_goodbye'] ? '{{ EXTENSION.extension_name|upper }}_HELLO' : '{{ EXTENSION.extension_name|upper }}_GOODBYE';
-		$this->template->assign_var('{{ EXTENSION.extension_name|upper }}_MESSAGE', $this->user->lang($l_message, $name));
+		$this->template->assign_var('{{ EXTENSION.extension_name|upper }}_MESSAGE', $this->{{ LANGUAGE.object }}->lang($l_message, $name));
 
 		return $this->helper->render('{{ EXTENSION.extension_name|lower }}_body.html', $name);
 	}

--- a/skeleton/controller/mcp_controller.php.twig
+++ b/skeleton/controller/mcp_controller.php.twig
@@ -36,7 +36,7 @@ class mcp_controller
 	 */
 	public function __construct({{ LANGUAGE.class }} ${{ LANGUAGE.object }}, \phpbb\request\request $request, \phpbb\template\template $template)
 	{
-		$this->{{ LANGUAGE.object }}	= ${{ LANGUAGE.object }};
+		$this->{{ LANGUAGE.object ~ LANGUAGE.indent.object }}	= ${{ LANGUAGE.object }};
 		$this->request	= $request;
 		$this->template	= $template;
 	}

--- a/skeleton/controller/mcp_controller.php.twig
+++ b/skeleton/controller/mcp_controller.php.twig
@@ -15,8 +15,8 @@ namespace {{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller;
  */
 class mcp_controller
 {
-	/** @var \phpbb\language\language */
-	protected $lang;
+	/** @var {{ LANGUAGE.class }} */
+	protected ${{ LANGUAGE.object }};
 
 	/** @var \phpbb\request\request */
 	protected $request;
@@ -30,13 +30,13 @@ class mcp_controller
 	/**
 	 * Constructor.
 	 *
-	 * @param \phpbb\language\language			$lang		Language object
-	 * @param \phpbb\request\request			$request	Request object
-	 * @param \phpbb\template\template			$template	Template object
+	 * @param {{ LANGUAGE.class ~ LANGUAGE.indent.class }}		${{ LANGUAGE.object ~ LANGUAGE.indent.object}}	{{ LANGUAGE.object|capitalize }} object
+	 * @param \phpbb\request\request		$request	Request object
+	 * @param \phpbb\template\template		$template	Template object
 	 */
-	public function __construct(\phpbb\language\language $lang, \phpbb\request\request $request, \phpbb\template\template $template)
+	public function __construct({{ LANGUAGE.class }} ${{ LANGUAGE.object }}, \phpbb\request\request $request, \phpbb\template\template $template)
 	{
-		$this->lang		= $lang;
+		$this->{{ LANGUAGE.object }}	= ${{ LANGUAGE.object }};
 		$this->request	= $request;
 		$this->template	= $template;
 	}
@@ -60,7 +60,7 @@ class mcp_controller
 			// Test if the submitted form is valid
 			if (!check_form_key('{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_mcp'))
 			{
-				$errors[] = $this->lang->lang('FORM_INVALID');
+				$errors[] = $this->{{ LANGUAGE.object }}->lang('FORM_INVALID');
 			}
 
 			// If no errors, process the form data

--- a/skeleton/controller/ucp_controller.php.twig
+++ b/skeleton/controller/ucp_controller.php.twig
@@ -17,9 +17,11 @@ class ucp_controller
 {
 	/** @var \phpbb\db\driver\driver_interface */
 	protected $db;
+{% if LANGUAGE.object == 'language' %}
 
 	/** @var \phpbb\language\language */
-	protected $lang;
+	protected $language;
+{% endif %}
 
 	/** @var \phpbb\request\request */
 	protected $request;
@@ -37,15 +39,19 @@ class ucp_controller
 	 * Constructor.
 	 *
 	 * @param \phpbb\db\driver\driver_interface	$db			Database object
-	 * @param \phpbb\language\language			$lang		Language object
+ {% if LANGUAGE.object == 'language' %}
+	 * @param \phpbb\language\language			$language	Language object
+ {% endif %}
 	 * @param \phpbb\request\request			$request	Request object
 	 * @param \phpbb\template\template			$template	Template object
 	 * @param \phpbb\user						$user		User object
 	 */
-	public function __construct(\phpbb\db\driver\driver_interface $db, \phpbb\language\language $lang, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\user $user)
+	public function __construct(\phpbb\db\driver\driver_interface $db, {% if LANGUAGE.object == 'language' %} \phpbb\language\language $language,{% endif %} \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\user $user)
 	{
 		$this->db		= $db;
-		$this->lang		= $lang;
+{% if LANGUAGE.object == 'language' %}
+		$this->language	= $language;
+{% endif %}
 		$this->request	= $request;
 		$this->template	= $template;
 		$this->user		= $user;
@@ -75,7 +81,7 @@ class ucp_controller
 			// Test if the submitted form is valid
 			if (!check_form_key('{{ EXTENSION.vendor_name|lower }}_{{ EXTENSION.extension_name|lower }}_ucp'))
 			{
-				$errors[] = $this->lang->lang('FORM_INVALID');
+				$errors[] = $this->{{ LANGUAGE.object }}->lang('FORM_INVALID');
 			}
 
 			// If no errors, process the form data
@@ -90,7 +96,7 @@ class ucp_controller
 				// Option settings have been updated
 				// Confirm this to the user and provide (automated) link back to previous page
 				meta_refresh(3, $this->u_action);
-				$message = $this->lang->lang('UCP_{{ EXTENSION.extension_name|upper }}_SAVED') . '<br /><br />' . $this->lang->lang('RETURN_UCP', '<a href="' . $this->u_action . '">', '</a>');
+				$message = $this->{{ LANGUAGE.object }}->lang('UCP_{{ EXTENSION.extension_name|upper }}_SAVED') . '<br /><br />' . $this->{{ LANGUAGE.object }}->lang('RETURN_UCP', '<a href="' . $this->u_action . '">', '</a>');
 				trigger_error($message);
 			}
 		}

--- a/skeleton/event/main_listener.php.twig
+++ b/skeleton/event/main_listener.php.twig
@@ -41,8 +41,8 @@ class main_listener implements EventSubscriberInterface
 	/* @var \phpbb\template\template */
 	protected $template;
 
-	/* @var \phpbb\user */
-	protected $user;
+	/* @var {{ LANGUAGE.class }} */
+	protected ${{ LANGUAGE.object }};
 
 	/** @var string phpEx */
 	protected $php_ext;
@@ -52,14 +52,14 @@ class main_listener implements EventSubscriberInterface
 	 *
 	 * @param \phpbb\controller\helper	$helper		Controller helper object
 	 * @param \phpbb\template\template	$template	Template object
-	 * @param \phpbb\user               $user       User object
+	 * @param {{ LANGUAGE.class ~ LANGUAGE.indent.class }}	${{ LANGUAGE.object ~ LANGUAGE.indent.object}}	{{ LANGUAGE.object|capitalize }} object
 	 * @param string                    $php_ext    phpEx
 	 */
-	public function __construct(\phpbb\controller\helper $helper, \phpbb\template\template $template, \phpbb\user $user, $php_ext)
+	public function __construct(\phpbb\controller\helper $helper, \phpbb\template\template $template, {{ LANGUAGE.class }} ${{ LANGUAGE.object }}, $php_ext)
 	{
 		$this->helper   = $helper;
 		$this->template = $template;
-		$this->user     = $user;
+		$this->{{ LANGUAGE.object ~ LANGUAGE.indent.object }}    = ${{ LANGUAGE.object }};
 		$this->php_ext  = $php_ext;
 	}
 
@@ -97,7 +97,7 @@ class main_listener implements EventSubscriberInterface
 	{
 		if ($event['on_page'][1] === 'app' && strrpos($event['row']['session_page'], 'app.' . $this->php_ext . '/demo') === 0)
 		{
-			$event['location'] = $this->user->lang('VIEWING_{{ EXTENSION.vendor_name|upper }}_{{ EXTENSION.extension_name|upper }}');
+			$event['location'] = $this->{{ LANGUAGE.object }}->lang('VIEWING_{{ EXTENSION.vendor_name|upper }}_{{ EXTENSION.extension_name|upper }}');
 			$event['location_url'] = $this->helper->route('{{ EXTENSION.vendor_name }}_{{ EXTENSION.extension_name }}_controller', array('name' => 'world'));
 		}
 	}
@@ -113,7 +113,7 @@ class main_listener implements EventSubscriberInterface
 	public function display_forums_modify_template_vars($event)
 	{
 		$forum_row = $event['forum_row'];
-		$forum_row['FORUM_NAME'] .= ' :: ' . $this->user->lang('{{ EXTENSION.extension_name|upper }}_EVENT') . ' :: ';
+		$forum_row['FORUM_NAME'] .= ' :: ' . $this->{{ LANGUAGE.object }}->lang('{{ EXTENSION.extension_name|upper }}_EVENT') . ' :: ';
 		$event['forum_row'] = $forum_row;
 	}
 {% endif %}

--- a/skeleton/mcp/main_module.php.twig
+++ b/skeleton/mcp/main_module.php.twig
@@ -26,14 +26,14 @@ class main_module
 		/** @var \{{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\mcp_controller $mcp_controller */
 		$mcp_controller = $phpbb_container->get('{{ EXTENSION.vendor_name }}.{{ EXTENSION.extension_name }}.controller.mcp');
 
-		/** @var \phpbb\language\language $language */
-		$language = $phpbb_container->get('language');
+		/** @var {{ LANGUAGE.class }} ${{ LANGUAGE.object }} */
+		${{ LANGUAGE.object }} = $phpbb_container->get('{{ LANGUAGE.object }}');
 
 		// Load a template for our MCP page
 		$this->tpl_name = 'mcp_{{ EXTENSION.extension_name|lower }}_body';
 
 		// Set the page title for our MCP page
-		$this->page_title = $language->lang('MCP_{{ EXTENSION.extension_name|upper }}_TITLE');
+		$this->page_title = ${{ LANGUAGE.object }}->lang('MCP_{{ EXTENSION.extension_name|upper }}_TITLE');
 
 		// Make the $u_action url available in our MCP controller
 		$mcp_controller->set_page_url($this->u_action);

--- a/skeleton/notification/type/sample.php.twig
+++ b/skeleton/notification/type/sample.php.twig
@@ -118,7 +118,7 @@ class sample extends \phpbb\notification\type\base
 	 */
 	public function get_title()
 	{
-		return $this->user->lang('{{ EXTENSION.vendor_name|upper }}_{{ EXTENSION.extension_name|upper }}_NOTIFICATION');
+		return $this->{{ LANGUAGE.object }}->lang('{{ EXTENSION.vendor_name|upper }}_{{ EXTENSION.extension_name|upper }}_NOTIFICATION');
 	}
 
 	/**

--- a/skeleton/tests/controller/main_test.php.twig
+++ b/skeleton/tests/controller/main_test.php.twig
@@ -39,13 +39,13 @@ class main_test extends \phpbb_test_case
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \phpbb\user|\PHPUnit_Framework_MockObject_MockObject $user Mock the user class */
-		$user = $this->getMockBuilder('\phpbb\user')
+		/** @var {{ LANGUAGE.class }}|\PHPUnit_Framework_MockObject_MockObject ${{ LANGUAGE.object }} Mock the {{ LANGUAGE.object }} class */
+		${{ LANGUAGE.object }} = $this->getMockBuilder('{{ LANGUAGE.class }}')
 			->disableOriginalConstructor()
 			->getMock();
 
-		// Set user->lang() to return any arguments sent to it
-		$user->expects($this->any())
+		// Set {{ LANGUAGE.object }}->lang() to return any arguments sent to it
+		${{ LANGUAGE.object }}->expects($this->any())
 			->method('lang')
 			->will($this->returnArgument(0));
 
@@ -66,7 +66,7 @@ class main_test extends \phpbb_test_case
 			new \phpbb\config\config(array()),
 			$controller_helper,
 			$template,
-			$user
+			${{ LANGUAGE.object }}
 		);
 
 		$response = $controller->handle('test');

--- a/skeleton/ucp/main_module.php.twig
+++ b/skeleton/ucp/main_module.php.twig
@@ -26,14 +26,14 @@ class main_module
 		/** @var \{{ EXTENSION.vendor_name }}\{{ EXTENSION.extension_name }}\controller\ucp_controller $ucp_controller */
 		$ucp_controller = $phpbb_container->get('{{ EXTENSION.vendor_name }}.{{ EXTENSION.extension_name }}.controller.ucp');
 
-		/** @var \phpbb\language\language $language */
-		$language = $phpbb_container->get('language');
+		/** @var {{ LANGUAGE.class }} ${{ LANGUAGE.object }} */
+		${{ LANGUAGE.object }} = $phpbb_container->get('{{ LANGUAGE.object }}');
 
 		// Load a template for our UCP page
 		$this->tpl_name = 'ucp_{{ EXTENSION.extension_name|lower }}_body';
 
 		// Set the page title for our UCP page
-		$this->page_title = $language->lang('UCP_{{ EXTENSION.extension_name|upper }}_TITLE');
+		$this->page_title = ${{ LANGUAGE.object }}->lang('UCP_{{ EXTENSION.extension_name|upper }}_TITLE');
 
 		// Make the $u_action url available in our UCP controller
 		$ucp_controller->set_page_url($this->u_action);


### PR DESCRIPTION
Only did the ACP controller for now, to show how it could be done.
Ofcourse function naming (`get_language_object`) and positioning is up to your preferences, so if you want that adjusted, let me know.
Currently using `$this->user->lang('')` for 3.1, which works perfectly fine, or does that have to be `$this->user->lang['']`. _Brackets changes from `()` to `[]`._
For ease of usage this will change `$this->lang` into `$this->language`, but if you want it's also possible to use `$lang` instead.

Let me know! :)