### PR TITLE
Display name fixes with special characters

### DIFF
--- a/helper/validator.php
+++ b/helper/validator.php
@@ -75,9 +75,9 @@ class validator
 	 */
 	public function validate_extension_display_name($value)
 	{
-		if ($value !== '')
+		if ($value !== '' && strpos($value, '&quot;') === false)
 		{
-			return $value;
+			return htmlspecialchars_decode($value, ENT_NOQUOTES);
 		}
 
 		throw new runtime_exception($this->language->lang('SKELETON_INVALID_DISPLAY_NAME'));

--- a/skeleton/build.xml.twig
+++ b/skeleton/build.xml.twig
@@ -9,7 +9,7 @@
 {% set destination = '${' ~ 'destination-filename}' %}
 {% set dependencies = '${' ~ 'has-dependencies}' %}
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="{{ EXTENSION.extension_display_name }} Build Script" description="Builds an extension.zip from a git repository" default="all">
+<project name="{{ EXTENSION.extension_display_name|e('html') }} Build Script" description="Builds an extension.zip from a git repository" default="all">
 	<property name="vendor-name" value="{{ EXTENSION.vendor_name }}" />
 	<property name="extension-name" value="{{ EXTENSION.extension_name }}" />
 	<!--

--- a/skeleton/controller/main_controller.php.twig
+++ b/skeleton/controller/main_controller.php.twig
@@ -44,7 +44,7 @@ class main_controller
 	}
 
 	/**
-	 * {{ EXTENSION.extension_display_name }} controller for route /demo/{{ '{' ~ 'name}' }}
+	 * Controller handler for route /demo/{{ '{' ~ 'name}' }}
 	 *
 	 * @param string $name
 	 *


### PR DESCRIPTION
Currently `&` is being encoded. So your display name would appear as `His &amp; Hers Extension` which is wrong. This fixes the display name usage, and only escapes it where needed.

This also makes double quote `"` an illegal character to use in a Display name, since that can cause additional problems. Yes we could try escaping that correctly in the various JSON, XML HTML and PHP files, but that character has no meaningful use in the display name so we should just make it invalid IMO.