### PR TITLE
Create composer.json as a twig template

### DIFF
--- a/controller/main.php
+++ b/controller/main.php
@@ -236,18 +236,11 @@ class main
 	 */
 	protected function get_user_input($value, $default, $array_key = null)
 	{
+		$return_value = $this->get_request_variable($value, $default, $array_key);
+
 		if (method_exists($this->validator, 'validate_' . $value))
 		{
-			$return_value = $this->get_request_variable($value, $default, $array_key);
 			$return_value = call_user_func([$this->validator, 'validate_' . $value], $return_value);
-		}
-		else if (is_bool($default))
-		{
-			$return_value = $this->get_request_variable($value, $default, $array_key);
-		}
-		else
-		{
-			$return_value = $this->get_request_variable($value, $default, $array_key);
 		}
 
 		return $return_value;

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -75,7 +75,7 @@ class packager
 			'requirements' => [
 				'php_version'       => '>=5.4',
 				'phpbb_version_min' => '>=3.2.0',
-				'phpbb_version_max' => '<3.4.0@dev',
+				'phpbb_version_max' => '<4.0.0@dev',
 			],
 		];
 	}

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -200,20 +200,29 @@ class packager
 			'assets_version'  => null,
 		]);
 
+		$path_helper = $this->phpbb_container->get('path_helper');
+		$environment = new environment(
+			$config,
+			$this->phpbb_container->get('filesystem'),
+			$path_helper,
+			$this->phpbb_container->getParameter('core.cache_dir'),
+			$this->phpbb_container->get('ext.manager'),
+			new loader(
+				new \phpbb\filesystem\filesystem()
+			)
+		);
+
+		// Custom filter for use by packager to decode greater/less than symbols
+		$filter = new \Twig\TwigFilter('skeleton_decode', function ($string) {
+			return str_replace(['&lt;', '&gt;'], ['<', '>'], $string);
+		}, ['is_safe' => ['html']]);
+		$environment->addFilter($filter);
+
 		$template_engine = new twig(
-			$this->phpbb_container->get('path_helper'),
+			$path_helper,
 			$config,
 			new context(),
-			new environment(
-				$config,
-				$this->phpbb_container->get('filesystem'),
-				$this->phpbb_container->get('path_helper'),
-				$this->phpbb_container->getParameter('core.cache_dir'),
-				$this->phpbb_container->get('ext.manager'),
-				new loader(
-					new \phpbb\filesystem\filesystem()
-				)
-			),
+			$environment,
 			$this->phpbb_container->getParameter('core.cache_dir'),
 			$this->phpbb_container->get('user'),
 			[

--- a/helper/packager.php
+++ b/helper/packager.php
@@ -129,6 +129,7 @@ class packager
 
 		$component_data = $this->get_component_dialog_values();
 		$skeleton_files[] = [
+			'composer.json',
 			'license.txt',
 			'README.md',
 		];
@@ -149,8 +150,6 @@ class packager
 				->assign_display('body');
 			$filesystem->dumpFile($ext_path . str_replace('demo', strtolower($data['extension']['extension_name']), $file), trim($body) . "\n");
 		}
-
-		$filesystem->dumpFile($ext_path . 'composer.json', $this->get_composer_json_from_data($data));
 	}
 
 	/**
@@ -186,58 +185,6 @@ class packager
 		$zip_archive->close();
 
 		return $zip_path;
-	}
-
-	/**
-	 * Get composer JSON info from extension data
-	 *
-	 * @param array $data Extension data
-	 *
-	 * @return string
-	 */
-	public function get_composer_json_from_data($data)
-	{
-		$composer = [
-			'name'        => "{$data['extension']['vendor_name']}/{$data['extension']['extension_name']}",
-			'type'        => 'phpbb-extension',
-			'description' => (string) $data['extension']['extension_description'],
-			'homepage'    => (string) $data['extension']['extension_homepage'],
-			'version'     => (string) $data['extension']['extension_version'],
-			'time'        => (string) $data['extension']['extension_time'],
-			'license'     => 'GPL-2.0-only',
-			'authors'     => [],
-			'require'     => [
-				'php'     => (string) $data['requirements']['php_version'],
-				'composer/installers' => '~1.0',
-			],
-			'extra'       => [
-				'display-name' => (string) $data['extension']['extension_display_name'],
-				'soft-require' => [
-					'phpbb/phpbb' => "{$data['requirements']['phpbb_version_min']},{$data['requirements']['phpbb_version_max']}",
-				],
-			],
-		];
-
-		if (!empty($data['components']['build']))
-		{
-			$composer['require-dev']['phing/phing'] = '2.4.*';
-		}
-
-		foreach ($data['authors'] as $i => $author_data)
-		{
-			$composer['authors'][] = [
-				'name'     => (string) $data['authors'][$i]['author_name'],
-				'email'    => (string) $data['authors'][$i]['author_email'],
-				'homepage' => (string) $data['authors'][$i]['author_homepage'],
-				'role'     => (string) $data['authors'][$i]['author_role'],
-			];
-		}
-
-		$body = json_encode($composer, JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES + JSON_UNESCAPED_UNICODE);
-		$body = str_replace(['&lt;', '&gt;'], ['<', '>'], $body);
-		$body .= PHP_EOL;
-
-		return $body;
 	}
 
 	/**

--- a/helper/validator.php
+++ b/helper/validator.php
@@ -33,11 +33,11 @@ class validator
 
 	/**
 	 * Validate the number of authors
-	 * Should be between 0 and 20
+	 * Should be between 1 and 20
 	 *
 	 * @param string $value The value to validate
-	 * @throws runtime_exception
 	 * @return string The valid value
+	 * @throws runtime_exception
 	 */
 	public function validate_num_authors($value)
 	{
@@ -50,11 +50,11 @@ class validator
 	}
 
 	/**
-	 * Validate the extension name
+	 * Validate and require the extension name
 	 *
 	 * @param string $value The value to validate
-	 * @throws runtime_exception
 	 * @return string The valid value
+	 * @throws runtime_exception
 	 */
 	public function validate_extension_name($value)
 	{
@@ -67,15 +67,15 @@ class validator
 	}
 
 	/**
-	 * Validate the extension display name
+	 * Validate and require the extension display name
 	 *
 	 * @param string $value The value to validate
-	 * @throws runtime_exception
 	 * @return string The valid value
+	 * @throws runtime_exception
 	 */
 	public function validate_extension_display_name($value)
 	{
-		if ($value !== '' && strpos($value, '&quot;') === false)
+		if ((string) $value !== '' && strpos($value, '&quot;') === false)
 		{
 			return htmlspecialchars_decode($value, ENT_NOQUOTES);
 		}
@@ -84,11 +84,11 @@ class validator
 	}
 
 	/**
-	 * Validate the extension date/time
+	 * Validate and require the extension date/time
 	 *
 	 * @param string $value The value to validate
-	 * @throws runtime_exception
 	 * @return string The valid value
+	 * @throws runtime_exception
 	 */
 	public function validate_extension_time($value)
 	{
@@ -101,11 +101,11 @@ class validator
 	}
 
 	/**
-	 * Validate the extension version number
+	 * Validate and require the extension version number
 	 *
 	 * @param string $value The value to validate
-	 * @throws runtime_exception
 	 * @return string The valid value
+	 * @throws runtime_exception
 	 */
 	public function validate_extension_version($value)
 	{
@@ -118,11 +118,11 @@ class validator
 	}
 
 	/**
-	 * Validate the extension vendor name
+	 * Validate and require the extension vendor name
 	 *
 	 * @param string $value The value to validate
-	 * @throws runtime_exception
 	 * @return string The valid value
+	 * @throws runtime_exception
 	 */
 	public function validate_vendor_name($value)
 	{
@@ -132,5 +132,124 @@ class validator
 		}
 
 		throw new runtime_exception($this->language->lang('SKELETON_INVALID_VENDOR_NAME'));
+	}
+
+	/**
+	 * Validate the extension homepage URL
+	 *
+	 * @param string $value The value to validate
+	 * @return string The valid value
+	 * @throws runtime_exception
+	 */
+	public function validate_extension_homepage($value)
+	{
+		if ((string) $value !== '' && filter_var($value, FILTER_VALIDATE_URL) === false)
+		{
+			throw new runtime_exception($this->language->lang('SKELETON_INVALID_EXTENSION_URL'));
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Validate the author homepage URL
+	 *
+	 * @param string $value The value to validate
+	 * @return string The valid value
+	 * @throws runtime_exception
+	 */
+	public function validate_author_homepage($value)
+	{
+		if ((string) $value !== '' && filter_var($value, FILTER_VALIDATE_URL) === false)
+		{
+			throw new runtime_exception($this->language->lang('SKELETON_INVALID_AUTHOR_URL'));
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Validate the author email
+	 *
+	 * @param string $value The value to validate
+	 * @return string The valid value
+	 * @throws runtime_exception
+	 */
+	public function validate_author_email($value)
+	{
+		if ((string) $value !== '' && filter_var($value, FILTER_VALIDATE_EMAIL) === false)
+		{
+			throw new runtime_exception($this->language->lang('SKELETON_INVALID_AUTHOR_EMAIL'));
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Validate and require the phpBB minimum version
+	 *
+	 * @param string $value The value to validate
+	 * @return string The valid value
+	 * @throws runtime_exception
+	 */
+	public function validate_phpbb_version_min($value)
+	{
+		if ($this->check_version($value))
+		{
+			return $value;
+		}
+
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_PHPBB_MIN_VERSION'));
+
+	}
+
+	/**
+	 * Validate and require the phpBB maximum version
+	 *
+	 * @param string $value The value to validate
+	 * @return string The valid value
+	 * @throws runtime_exception
+	 */
+	public function validate_phpbb_version_max($value)
+	{
+		if ($this->check_version($value))
+		{
+			return $value;
+		}
+
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_PHPBB_MAX_VERSION'));
+
+	}
+
+	/**
+	 * Validate and require the PHP version
+	 *
+	 * @param string $value The value to validate
+	 * @return string The valid value
+	 * @throws runtime_exception
+	 */
+	public function validate_php_version($value)
+	{
+		if ($this->check_version($value))
+		{
+			return $value;
+		}
+
+		throw new runtime_exception($this->language->lang('SKELETON_INVALID_PHP_VERSION'));
+
+	}
+
+	/**
+	 * Version value check. Checks for values like:
+	 *     1.0.0-RC1
+	 *     >=1.0.0
+	 *     <1.0@dev
+	 *
+	 * @param string $value The value to check
+	 * @return bool True if valid, false if not
+	 */
+	protected function check_version($value)
+	{
+		return (bool) preg_match('/^[<>=]*[\d+][\w.@-]+$/', $value);
 	}
 }

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -141,12 +141,18 @@ $lang = array_merge($lang, [
 	'SKELETON_TITLE_REQUIREMENT_INFO'	=> 'Requirements',
 	'SKELETON_TITLE_COMPONENT_INFO'		=> 'Components',
 
+	'SKELETON_INVALID_AUTHOR_EMAIL'		=> 'An author email is invalid',
+	'SKELETON_INVALID_AUTHOR_URL'		=> 'An author homepage URL is invalid',
 	'SKELETON_INVALID_DISPLAY_NAME'		=> 'The display name you provided is invalid',
 	'SKELETON_INVALID_EXTENSION_TIME'	=> 'The extension date you provided is invalid',
+	'SKELETON_INVALID_EXTENSION_URL'	=> 'The extension homepage URL is invalid',
 	'SKELETON_INVALID_EXTENSION_VERSION'=> 'The extension version you provided is invalid',
 	'SKELETON_INVALID_NUM_AUTHORS'		=> 'The number of authors you provided is invalid',
 	'SKELETON_INVALID_PACKAGE_NAME'		=> 'The package name you provided is invalid',
 	'SKELETON_INVALID_VENDOR_NAME'		=> 'The vendor name you provided is invalid',
+	'SKELETON_INVALID_PHP_VERSION'		=> 'The PHP version requirement is invalid.',
+	'SKELETON_INVALID_PHPBB_MIN_VERSION'=> 'The minimum phpBB version requirement is invalid.',
+	'SKELETON_INVALID_PHPBB_MAX_VERSION'=> 'The maximum phpBB version requirement is invalid.',
 
 	'NO_ZIPARCHIVE_ERROR'	=> 'The ZipArchive class is required, but was not found in your PHP configuration.',
 	'PHP_VERSION_ERROR'		=> 'PHP 5.4 or newer is required to use this extension.',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -75,7 +75,7 @@ $lang = array_merge($lang, [
 	'SKELETON_QUESTION_PHPBB_VERSION_MIN_EXPLAIN'	=> 'default: &gt;=3.2.0',
 	'SKELETON_QUESTION_PHPBB_VERSION_MAX'			=> 'Please enter the maximum phpBB requirement of the extension',
 	'SKELETON_QUESTION_PHPBB_VERSION_MAX_UI'		=> 'Maximum phpBB requirement of the extension',
-	'SKELETON_QUESTION_PHPBB_VERSION_MAX_EXPLAIN'	=> 'default: &lt;3.4.0@dev',
+	'SKELETON_QUESTION_PHPBB_VERSION_MAX_EXPLAIN'	=> 'default: &lt;4.0.0@dev',
 
 	'SKELETON_QUESTION_COMPONENT_PHPLISTENER'		=> 'Create sample PHP event listeners?',
 	'SKELETON_QUESTION_COMPONENT_PHPLISTENER_UI'	=> 'PHP event listeners',

--- a/skeleton/composer.json.twig
+++ b/skeleton/composer.json.twig
@@ -1,0 +1,35 @@
+{
+    "name": "{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}",
+    "type": "phpbb-extension",
+    "description": "{{ EXTENSION.extension_description|replace({'&lt;': '<', '&gt;': '>'}) }}",
+    "homepage": "{{ EXTENSION.extension_homepage }}",
+    "version": "{{ EXTENSION.extension_version }}",
+    "time": "{{ EXTENSION.extension_time }}",
+    "license": "GPL-2.0-only",
+    "authors": [
+{% for AUTHOR in AUTHORS %}
+        {
+            "name": "{{ AUTHOR.author_name|replace({'&lt;': '<', '&gt;': '>'}) }}",
+            "email": "{{ AUTHOR.author_email }}",
+            "homepage": "{{ AUTHOR.author_homepage }}",
+            "role": "{{ AUTHOR.author_role|replace({'&lt;': '<', '&gt;': '>'}) }}"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    ],
+    "require": {
+        "php": "{{ REQUIREMENTS.php_version }}",
+        "composer/installers": "~1.0"
+    },
+{% if COMPONENT.build %}
+    "require-dev": {
+        "phing/phing": "2.4.*"
+    },
+{% endif %}
+    "extra": {
+        "display-name": "{{ EXTENSION.extension_display_name }}",
+        "soft-require": {
+            "phpbb/phpbb": "{{ REQUIREMENTS.phpbb_version_min }},{{ REQUIREMENTS.phpbb_version_max }}"
+        }
+    }
+}

--- a/skeleton/composer.json.twig
+++ b/skeleton/composer.json.twig
@@ -1,7 +1,8 @@
+{% apply skeleton_decode %}
 {
     "name": "{{ EXTENSION.vendor_name }}/{{ EXTENSION.extension_name }}",
     "type": "phpbb-extension",
-    "description": "{{ EXTENSION.extension_description|replace({'&lt;': '<', '&gt;': '>'}) }}",
+    "description": "{{ EXTENSION.extension_description }}",
     "homepage": "{{ EXTENSION.extension_homepage }}",
     "version": "{{ EXTENSION.extension_version }}",
     "time": "{{ EXTENSION.extension_time }}",
@@ -9,10 +10,10 @@
     "authors": [
 {% for AUTHOR in AUTHORS %}
         {
-            "name": "{{ AUTHOR.author_name|replace({'&lt;': '<', '&gt;': '>'}) }}",
+            "name": "{{ AUTHOR.author_name }}",
             "email": "{{ AUTHOR.author_email }}",
             "homepage": "{{ AUTHOR.author_homepage }}",
-            "role": "{{ AUTHOR.author_role|replace({'&lt;': '<', '&gt;': '>'}) }}"
+            "role": "{{ AUTHOR.author_role }}"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -33,3 +34,4 @@
         }
     }
 }
+{% endapply %}

--- a/skeleton/composer.json.twig
+++ b/skeleton/composer.json.twig
@@ -14,8 +14,7 @@
             "email": "{{ AUTHOR.author_email }}",
             "homepage": "{{ AUTHOR.author_homepage }}",
             "role": "{{ AUTHOR.author_role }}"
-        }{% if not loop.last %},{% endif %}
-
+        }{{ not loop.last ? ',' }}
 {% endfor %}
     ],
     "require": {


### PR DESCRIPTION
I don't know why composer.json was being created via PHP originally, but this PR makes it a twig template like every other file skeleton creates. 

Also added a few more validators to user input while doing this.